### PR TITLE
In=javathread

### DIFF
--- a/data/completion.yaml
+++ b/data/completion.yaml
@@ -50,6 +50,11 @@ complete:
     opts:
     - name: javagcjoin=
       desc: If true it will return an array with each processed line.
+  - name: in=javathread
+    desc: A Java thread dump text file format or java pid
+    opts:
+    - name: javathreadpid=
+      desc: The PID of the Java process to connect to -requires Java SDK-
   - name: in=jmx
     desc: Uses Java JMX to retrieve data from another Java process
     opts:

--- a/data/usage.json
+++ b/data/usage.json
@@ -163,6 +163,10 @@
       "Description": "The Java GC log lines text format"
     },
     {
+      "Input type": "javathread",
+      "Description": "The Java Thread stack dump lines text format"
+    },
+    {
       "Input type": "jmx",
       "Description": "Uses Java JMX to retrieve data from another Java process"
     },
@@ -701,6 +705,13 @@
       "Option": "javagcjoin",
       "Type": "Boolean",
       "Description": "If true it will return an array with each processed line."
+    }
+  ],
+  [
+    {
+      "Option": "javathreadpid",
+      "Type": "Number",
+      "Description": "Optional you can provider the local java process pid to try to get the thread stack trace (*)"
     }
   ],
   [

--- a/src/docs/USAGE.md
+++ b/src/docs/USAGE.md
@@ -72,6 +72,7 @@ List of data input types that can be auto-detected (through the file extension o
 | ini | INI/Properties format |
 | javas | Tries to list java processes running locally (javainception=true to include itself) |
 | javagc | The Java GC log lines text format |
+| javathread | The Java Thread stack dump lines text format |
 | jmx | Uses Java JMX to retrieve data from another Java process |
 | json | A JSON format (auto-detected) |
 | jsonschema | Given a JSON schema format tries to generate sample data for it |
@@ -254,6 +255,20 @@ List of options to use when _in=javagc_:
 | Option | Type | Description |
 |--------|------|-------------|
 | javagcjoin | Boolean | If true it will return an array with each processed line. |
+
+---
+
+### 🧾 JavaThread input options
+
+List of options to use when _in=javathread_:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| javathreadpid | Number | Optional you can provider the local java process pid to try to get the thread stack trace (*) |
+
+> (*) This requires running openaf/oafp with a Java JDK. Keep in mind that it will interrupt the target application to dump the necessary data.
+
+> You can extract the input text data by executing ```kill -3 pid```
 
 ---
 

--- a/src/include/transformFns.js
+++ b/src/include/transformFns.js
@@ -196,6 +196,7 @@ var _transformFns = {
     },
     "correcttypes"  : _r => {
         if (toBoolean(params.correcttypes) && isObject(_r)) {
+            ow.loadFormat()
             traverse(_r, (aK, aV, aP, aO) => {
                 switch(descType(aV)) {
                 case "number": if (isString(aV)) aO[aK] = Number(aV); break
@@ -203,7 +204,11 @@ var _transformFns = {
                     // String boolean
                     if (aV.trim().toLowerCase() == "true" || aV.trim().toLowerCase() == "false") { aO[aK] = toBoolean(aV); break }
                     // String ISO date
-                    if (aV.trim().match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)) { aO[aK] = new Date(aV); break }
+                    if (isDef(ow.format.fromISODate)) {
+                        if (aV.trim().match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\d+Z$/)) { aO[aK] = ow.format.fromISODate(aV); break }
+                    } else {
+                        if (aV.trim().match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)) { aO[aK] = new Date(aV); break }
+                    }
                     // String date
                     if (aV.trim().match(/^\d{4}-\d{2}-\d{2}$/)) { aO[aK] = new Date(aV); break }
                     // String time with seconds
@@ -557,7 +562,7 @@ var _transformFns = {
         let _lst = params.field2date.split(",").map(r => r.trim())
         traverse(_r, (aK, aV, aP, aO) => {
             if (_lst.indexOf(aP.length > 0 && !aP.startsWith("[") ? aP.substring(1) + "." + aK : aK) >= 0 && isNumber(aV) && aV > 0) {
-                try { aO[aK] = new Date(aV) } catch(e) {}
+                try { aO[aK] = ow.format.fromISODate(aV) } catch(e) {}
             }
         })
         return _r


### PR DESCRIPTION
This pull request introduces a new input type `javathread` for handling Java thread dump text files or Java process IDs. The changes span multiple files to integrate this new feature, including updates to documentation, configuration files, and JavaScript functions.

### Integration of `javathread` input type:

* [`data/completion.yaml`](diffhunk://#diff-de5fee9ed7568901eb3257fa12d5749c423e146cfdc6e877d656f83c292b0413R53-R57): Added a new input type `javathread` with an option `javathreadpid` to specify the Java process ID.
* [`data/usage.json`](diffhunk://#diff-ada191f4a6b7fcbe303dcd62da73ca894f9be074df249a3482712ec95493202dR165-R168): Included descriptions for the new `javathread` input type and its option `javathreadpid`. [[1]](diffhunk://#diff-ada191f4a6b7fcbe303dcd62da73ca894f9be074df249a3482712ec95493202dR165-R168) [[2]](diffhunk://#diff-ada191f4a6b7fcbe303dcd62da73ca894f9be074df249a3482712ec95493202dR710-R716)
* [`src/docs/USAGE.md`](diffhunk://#diff-ed2fbc1b560501180b33c1f0bb35cd7c50bd673ff3efda8e21b849f6a0216454R75): Updated the documentation to include the new `javathread` input type and its options. [[1]](diffhunk://#diff-ed2fbc1b560501180b33c1f0bb35cd7c50bd673ff3efda8e21b849f6a0216454R75) [[2]](diffhunk://#diff-ed2fbc1b560501180b33c1f0bb35cd7c50bd673ff3efda8e21b849f6a0216454R261-R274)

### JavaScript function updates:

* [`src/include/inputFns.js`](diffhunk://#diff-3eadecb43bd979aea663b3a6b7ef57a1f69530759348793d15f20ac65349bfa0R511-R614): Implemented the logic to handle the `javathread` input type, including parsing thread dump lines and extracting relevant data.
* [`src/include/transformFns.js`](diffhunk://#diff-56705be6fa16ace5f4921d19116201358ec3bc0426867e793a831ccbc4fc1b43R199-R211): Modified transformation functions to handle date formats correctly, using `ow.format.fromISODate`. [[1]](diffhunk://#diff-56705be6fa16ace5f4921d19116201358ec3bc0426867e793a831ccbc4fc1b43R199-R211) [[2]](diffhunk://#diff-56705be6fa16ace5f4921d19116201358ec3bc0426867e793a831ccbc4fc1b43L560-R565)