### PR TITLE
Add NDJSON to JSON transformation tests and update YAML configuration

### DIFF
--- a/src/tests/autoTest.yaml
+++ b/src/tests/autoTest.yaml
@@ -8,6 +8,9 @@ todo:
 - oafp::JSON2Base64
 - oafp::JSON2Base64Gzip
 - oafp::CSV2JSON
+- oafp::NDJSON2JSON
+- oafp::NDJSON2JSON_2
+- oafp::NDJSON2JSON_2p
 
 - oafp::merge
 - oafp::sortMapKeys
@@ -115,6 +118,27 @@ jobs:
   deps: Load test
   args:
     func: "global.test.testJSON2Base64Gzip()"
+
+# -----------------------
+- name: oafp::NDJSON2JSON
+  to  : oJob Test
+  deps: Load test
+  args:
+    func: "global.test.testNDJSON2JSON()"
+
+# -------------------------
+- name: oafp::NDJSON2JSON_2
+  to  : oJob Test
+  deps: Load test
+  args:
+    func: "global.test.testNDJSON2JSON_2()"
+
+# --------------------------
+- name: oafp::NDJSON2JSON_2p
+  to  : oJob Test
+  deps: Load test
+  args:
+    func: "global.test.testNDJSON2JSON_2p()"
 
 # -----------------
 - name: oafp::merge


### PR DESCRIPTION
This pull request introduces new tests and configurations for handling NDJSON (Newline-Delimited JSON) to JSON transformations in both sequential and parallel modes. The most important changes include the addition of three new test functions in `autoTest.js`, updates to the test list in `autoTest.yaml`, and the definition of corresponding jobs for these tests.

### Additions to NDJSON to JSON Testing:

* **New test functions in `src/tests/autoTest.js`:**
  - Added `testNDJSON2JSON` to validate basic NDJSON to JSON transformation.
  - Added `testNDJSON2JSON_2` to handle larger datasets with sequential processing.
  - Added `testNDJSON2JSON_2p` to test parallel processing of NDJSON to JSON.

* **Updates to `todo:` in `src/tests/autoTest.yaml`:**
  - Listed the new test cases `oafp::NDJSON2JSON`, `oafp::NDJSON2JSON_2`, and `oafp::NDJSON2JSON_2p` in the `todo:` section for execution.

* **Job definitions in `jobs:` in `src/tests/autoTest.yaml`:**
  - Defined jobs for the new test cases, specifying dependencies and the functions to execute:
    - `oafp::NDJSON2JSON` (basic transformation).
    - `oafp::NDJSON2JSON_2` (sequential processing of large datasets).
    - `oafp::NDJSON2JSON_2p` (parallel processing of large datasets).