### PR TITLE
Add fallback to OAF_MODEL when OAFP_MODEL missing

### DIFF
--- a/src/docs/USAGE.md
+++ b/src/docs/USAGE.md
@@ -681,6 +681,7 @@ List of options to use when _in=llm_ or _llmprompt=..._:
 > OpenAF sBuckets are supported in llmoptions. You can set any of the environment variables OAFP_SECREPO, OAFP_SECBUCKET, OAFP_SECPASS, OAFP_SECMAINPASS and OAFP_SECFILE OR set the corresponding map values secRepo, secBucket, secPass, secMainPass and secFile.
 
 > Tip: Use the 'getlist=' optional transform to automatically filter list of data from LLMs prompt responses if relevant.
+> If `OAFP_MODEL` is not defined but `OAF_MODEL` is, the latter will be used automatically.
 > Example: `OAFP_MODEL="(type:ollama,model:llama3)" oafp llmprompt="hello world"`
 
 ---

--- a/src/include/inputFns.js
+++ b/src/include/inputFns.js
@@ -1,3 +1,13 @@
+if (typeof _resolveLLMEnvName === "undefined") {
+    var _resolveLLMEnvName = function (aEnv) {
+        var _env = aEnv
+        if (_env == "OAFP_MODEL" && isUnDef(getEnv("OAFP_MODEL")) && isDef(getEnv("OAF_MODEL"))) {
+            _env = "OAF_MODEL"
+        }
+        return _env
+    }
+}
+
 var _inputFns = new Map([
     ["?"    , (_res, options) => {
         _res = Array.from(_inputFns.keys()).filter(r => r != '?').sort()
@@ -1301,11 +1311,9 @@ var _inputFns = new Map([
     }],
     ["llm", (_res, options) => {
         params.llmenv     = _$(params.llmenv, "llmenv").isString().default("OAFP_MODEL")
+        params.llmenv     = _resolveLLMEnvName(params.llmenv)
         params.llmoptions = _$(params.llmoptions, "llmoptions").or().isString().isMap().default(__)
-        if (params.llmenv == "OAFP_MODEL" && isUnDef(getEnv("OAFP_MODEL")) && isDef(getEnv("OAF_MODEL"))) {
-            params.llmenv = "OAF_MODEL"
-        }
-        if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv))) 
+        if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv)))
             _exit(-1, "llmoptions not defined and " + params.llmenv + " not found.")
 
         _showTmpMsg()
@@ -1339,12 +1347,10 @@ var _inputFns = new Map([
     }],
     ["llmmodels", (_res, options) => {
         params.llmenv     = _$(params.llmenv, "llmenv").isString().default("OAFP_MODEL")
+        params.llmenv     = _resolveLLMEnvName(params.llmenv)
         params.llmoptions = _$(params.llmoptions, "llmoptions").or().isString().isMap().default(__)
-        if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv))) 
+        if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv)))
             _exit(-1, "llmoptions not defined and " + params.llmenv + " not found.")
-        if (params.llmenv == "OAFP_MODEL" && isUnDef(getEnv("OAFP_MODEL")) && isDef(getEnv("OAF_MODEL"))) {
-            params.llmenv = "OAF_MODEL"
-        }
         _showTmpMsg()
 
         var res = $llm( _getSec(isDef(params.llmoptions) ? _fromJSSLON(params.llmoptions) : $sec("system", "envs").get(params.llmenv)) )

--- a/src/include/transformFns.js
+++ b/src/include/transformFns.js
@@ -1,3 +1,13 @@
+if (typeof _resolveLLMEnvName === "undefined") {
+    var _resolveLLMEnvName = function (aEnv) {
+        var _env = aEnv
+        if (_env == "OAFP_MODEL" && isUnDef(getEnv("OAFP_MODEL")) && isDef(getEnv("OAF_MODEL"))) {
+            _env = "OAF_MODEL"
+        }
+        return _env
+    }
+}
+
 var _transformFns = {
     "transforms"    : _r => {
         if (toBoolean(params.transforms)) {
@@ -268,8 +278,9 @@ var _transformFns = {
     "llmprompt": _r => {
         if (isString(params.llmprompt)) {
             params.llmenv     = _$(params.llmenv, "llmenv").isString().default("OAFP_MODEL")
+            params.llmenv     = _resolveLLMEnvName(params.llmenv)
             params.llmoptions = _$(params.llmoptions, "llmoptions").isString().default(__)
-            if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv))) 
+            if (isUnDef(params.llmoptions) && !isString(getEnv(params.llmenv)))
                 _exit(-1, "llmoptions not defined and " + params.llmenv + " not found.")
 
             var res = $llm( _getSec(isDef(params.llmoptions) ? params.llmoptions : $sec("system", "envs").get(params.llmenv)) )


### PR DESCRIPTION
## Summary
- add a reusable helper to reuse the OAF_MODEL environment variable when OAFP_MODEL is unset
- update llm input and transform flows to consume the fallback before validating configuration
- document the fallback behavior in the usage guide

## Testing
- not run
