### PR TITLE
Fix Java object conversion in ls input handler

### DIFF
--- a/src/include/inputFns.js
+++ b/src/include/inputFns.js
@@ -1460,9 +1460,9 @@ var _inputFns = new Map([
                 }
             } else {
                 if (toBoolean(params.lsrecursive)) {
-                    _r = listFilesRecursive(_res, isPosix)
+                    _r = af.fromJavaArray(listFilesRecursive(_res, isPosix))
                 } else {
-                    _r = io.listFiles(_res, isPosix).files
+                    _r = af.fromJavaMap(io.listFiles(_res, isPosix)).files
                 }
             }
             _$o(_r, options)


### PR DESCRIPTION
### Motivation
- Ensure Java-returned structures from `listFilesRecursive` and `io.listFiles` are converted to JavaScript values before use in the `in=ls` input path to avoid mixed Java/JS object handling.

### Description
- In `src/include/inputFns.js` wrap `listFilesRecursive(_res, isPosix)` with `af.fromJavaArray(...)` and wrap `io.listFiles(_res, isPosix)` with `af.fromJavaMap(...)` before accessing `.files`, so `in="ls"` returns proper JS arrays/maps.

### Testing
- No automated tests were added or executed for this change.
